### PR TITLE
Updated with recent version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId 'com.nilhcem.blenamebadge'
@@ -34,8 +33,8 @@ spotless {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     implementation 'com.jakewharton.timber:timber:4.7.0'
 


### PR DESCRIPTION
Update
    implementation 'com.android.support:appcompat-v7:27.1.1'
    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
Remove 
    buildToolsVersion '27.0.3'

Fixes #29

Changes: [Add here what changes were made in this issue and if possible provide links.]

Screenshots for the change:
![image](https://user-images.githubusercontent.com/24621468/51681863-ecbc4000-200b-11e9-9873-73b380d4078f.png)
