### PR TITLE
Update ext.kotlin_version to Recent #30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.3.11'
 
     repositories {
         google()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Fixes #30

Changes:
     ext.kotlin_version = '1.3.11'
     classpath 'com.android.tools.build:gradle:3.3.0'

Screenshots for the change:
![image](https://user-images.githubusercontent.com/24621468/51682381-4bce8480-200d-11e9-9489-81d506211c12.png)
